### PR TITLE
Qualify imports

### DIFF
--- a/credativ_pg_migrator/command_line.py
+++ b/credativ_pg_migrator/command_line.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
-from constants import MigratorConstants
+from credativ_pg_migrator.constants import MigratorConstants
 
 class CommandLine:
     def __init__(self):

--- a/credativ_pg_migrator/config_parser.py
+++ b/credativ_pg_migrator/config_parser.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import yaml
-from constants import MigratorConstants
+from credativ_pg_migrator.constants import MigratorConstants
 
 class ConfigParser:
     def __init__(self, args, logger):

--- a/credativ_pg_migrator/connectors/ibm_db2_connector.py
+++ b/credativ_pg_migrator/connectors/ibm_db2_connector.py
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from database_connector import DatabaseConnector
-from migrator_logging import MigratorLogger
+from credativ_pg_migrator.database_connector import DatabaseConnector
+from credativ_pg_migrator.migrator_logging import MigratorLogger
 import ibm_db_dbi
 import traceback
 

--- a/credativ_pg_migrator/connectors/informix_connector.py
+++ b/credativ_pg_migrator/connectors/informix_connector.py
@@ -15,8 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import jaydebeapi
-from database_connector import DatabaseConnector
-from migrator_logging import MigratorLogger
+from credativ_pg_migrator.database_connector import DatabaseConnector
+from credativ_pg_migrator.migrator_logging import MigratorLogger
 import re
 import traceback
 import pyodbc

--- a/credativ_pg_migrator/connectors/ms_sql_connector.py
+++ b/credativ_pg_migrator/connectors/ms_sql_connector.py
@@ -18,8 +18,8 @@ import jaydebeapi
 from jaydebeapi import Error
 import pyodbc
 from pyodbc import Error
-from database_connector import DatabaseConnector
-from migrator_logging import MigratorLogger
+from credativ_pg_migrator.database_connector import DatabaseConnector
+from credativ_pg_migrator.migrator_logging import MigratorLogger
 import re
 import traceback
 

--- a/credativ_pg_migrator/connectors/mysql_connector.py
+++ b/credativ_pg_migrator/connectors/mysql_connector.py
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from database_connector import DatabaseConnector
-from migrator_logging import MigratorLogger
+from credativ_pg_migrator.database_connector import DatabaseConnector
+from credativ_pg_migrator.migrator_logging import MigratorLogger
 import mysql.connector
 import traceback
 from tabulate import tabulate

--- a/credativ_pg_migrator/connectors/oracle_connector.py
+++ b/credativ_pg_migrator/connectors/oracle_connector.py
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from database_connector import DatabaseConnector
-from migrator_logging import MigratorLogger
+from credativ_pg_migrator.database_connector import DatabaseConnector
+from credativ_pg_migrator.migrator_logging import MigratorLogger
 import cx_Oracle
 import traceback
 from tabulate import tabulate

--- a/credativ_pg_migrator/connectors/postgresql_connector.py
+++ b/credativ_pg_migrator/connectors/postgresql_connector.py
@@ -17,8 +17,8 @@
 import psycopg2
 import psycopg2.extras
 from psycopg2 import sql
-from database_connector import DatabaseConnector
-from migrator_logging import MigratorLogger
+from credativ_pg_migrator.database_connector import DatabaseConnector
+from credativ_pg_migrator.migrator_logging import MigratorLogger
 import traceback
 import re
 

--- a/credativ_pg_migrator/connectors/sql_anywhere_connector.py
+++ b/credativ_pg_migrator/connectors/sql_anywhere_connector.py
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from database_connector import DatabaseConnector
-from migrator_logging import MigratorLogger
+from credativ_pg_migrator.database_connector import DatabaseConnector
+from credativ_pg_migrator.migrator_logging import MigratorLogger
 import sqlanydb
 import pyodbc
 import traceback

--- a/credativ_pg_migrator/connectors/sybase_ase_connector.py
+++ b/credativ_pg_migrator/connectors/sybase_ase_connector.py
@@ -18,8 +18,8 @@ import jaydebeapi
 from jaydebeapi import Error
 import pyodbc
 from pyodbc import Error
-from database_connector import DatabaseConnector
-from migrator_logging import MigratorLogger
+from credativ_pg_migrator.database_connector import DatabaseConnector
+from credativ_pg_migrator.migrator_logging import MigratorLogger
 import re
 import traceback
 from tabulate import tabulate

--- a/credativ_pg_migrator/main.py
+++ b/credativ_pg_migrator/main.py
@@ -18,12 +18,12 @@
 Migrator code
 source venv/bin/activate
 """
-from command_line import CommandLine
-from config_parser import ConfigParser
-from orchestrator import Orchestrator
-from migrator_logging import MigratorLogger
-from planner import Planner
-from constants import MigratorConstants
+from credativ_pg_migrator.command_line import CommandLine
+from credativ_pg_migrator.config_parser import ConfigParser
+from credativ_pg_migrator.orchestrator import Orchestrator
+from credativ_pg_migrator.migrator_logging import MigratorLogger
+from credativ_pg_migrator.planner import Planner
+from credativ_pg_migrator.constants import MigratorConstants
 import sys
 import os
 import traceback

--- a/credativ_pg_migrator/migrator_tables.py
+++ b/credativ_pg_migrator/migrator_tables.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
-from connectors.postgresql_connector import PostgreSQLConnector
+from credativ_pg_migrator.connectors.postgresql_connector import PostgreSQLConnector
 class MigratorTables:
     def __init__(self, logger, config_parser):
         self.logger = logger

--- a/credativ_pg_migrator/orchestrator.py
+++ b/credativ_pg_migrator/orchestrator.py
@@ -16,9 +16,9 @@
 
 import concurrent.futures
 import importlib
-from migrator_logging import MigratorLogger
-from migrator_tables import MigratorTables
-from constants import MigratorConstants
+from credativ_pg_migrator.migrator_logging import MigratorLogger
+from credativ_pg_migrator.migrator_tables import MigratorTables
+from credativ_pg_migrator.constants import MigratorConstants
 import traceback
 import uuid
 import fnmatch

--- a/credativ_pg_migrator/planner.py
+++ b/credativ_pg_migrator/planner.py
@@ -16,9 +16,9 @@
 
 import os
 import importlib
-from migrator_logging import MigratorLogger
-from migrator_tables import MigratorTables
-from constants import MigratorConstants
+from credativ_pg_migrator.migrator_logging import MigratorLogger
+from credativ_pg_migrator.migrator_tables import MigratorTables
+from credativ_pg_migrator.constants import MigratorConstants
 import fnmatch
 import traceback
 import re

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     description='Migrator from proprietary and legacy databases into PostgreSQL',
     packages=find_packages(),
     install_requires=['psycopg2', 'jaydebeapi', 'pyyaml', 'pandas', 'pyodbc', 'importlib', 'tabulate'],
-    entry_points={'console_scripts': ['credativ-pg-migrator = credativ_pg_migrator:main']},
+    entry_points={'console_scripts': ['credativ-pg-migrator = credativ_pg_migrator.main:main']},
 )


### PR DESCRIPTION
This makes it possible to run 
```
$ python3 -m pip install .
$ ./.venv/bin/credativ-pg-migrator --version
Database Migration Tool credativ-pg-migrator
Version: 0.8.3
```
